### PR TITLE
Move vertically by terminal rows (not lines)

### DIFF
--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -14,3 +14,7 @@ set("n", "<leader>tt4", ":set tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab<C
 -- Easy insertion of a trailing ; or , from insert mode
 vim.keymap.set('i', ';;', '<Esc>A;<Esc>')
 vim.keymap.set('i', ',,', '<Esc>A,<Esc>')
+
+-- When text is wrapped, move by terminal rows, not lines, unless a count is provided
+vim.keymap.set('n', 'k', "v:count == 0 ? 'gk' : 'k'", { expr = true })
+vim.keymap.set('n', 'j', "v:count == 0 ? 'gj' : 'j'", { expr = true })


### PR DESCRIPTION
When a long line of text is wrappped, using "j" and "k" should move down/up one terminal row (not lines defined by linebreaks)

The exception to this behavior is when a count is provided (e.g. 4j will move down 4 lines, if you have wrapped text this could be something like 8 terminal rows)

Resolves #2