### PR TITLE
Configure vim-commentary to use // in PHP

### DIFF
--- a/lua/config/commentary.lua
+++ b/lua/config/commentary.lua
@@ -1,0 +1,9 @@
+vim.api.nvim_create_autocmd(
+    "FileType",
+    {
+      pattern = {
+        "php",
+      },
+      command = "setlocal commentstring=//%s",
+    }
+)

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -50,7 +50,10 @@ packer.startup(function(use)
     branch = 'release',
     config = get_config("coc"),
   })
-  use({ "tpope/vim-commentary" })
+  use({
+    "tpope/vim-commentary",
+    config = get_config("commentary"),
+  })
   use({ "tpope/vim-unimpaired" })
   use({ "tpope/vim-vinegar" })
   use({ "vim-airline/vim-airline" })


### PR DESCRIPTION
Configure vim-commentary to use single line comments (//) in PHP
rather than multiline comments (/* */)

Resolves #1