### PR TITLE
Prevent directory buffer in tabline

### DIFF
--- a/lua/config/vinegar.lua
+++ b/lua/config/vinegar.lua
@@ -1,0 +1,1 @@
+vim.g.netrw_fastbrowse = 0

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -55,7 +55,10 @@ packer.startup(function(use)
     config = get_config("commentary"),
   })
   use({ "tpope/vim-unimpaired" })
-  use({ "tpope/vim-vinegar" })
+  use({
+    "tpope/vim-vinegar",
+    config = get_config("vinegar"),
+  })
   use({ "vim-airline/vim-airline" })
   use({
     "vim-airline/vim-airline-themes",


### PR DESCRIPTION
This is to resolve a bug where the directory buffer that is opened in netrw when using vim-vinegar would appear in the tabline list alongside the file buffers.

To prevent this we are setting g:netrw_fastbrowse to 0

Resolves #5