### PR TITLE
Add :JSONFormat command

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,4 @@
+require("commands")
 require("mappings")
 require("plugins")
 require("options")

--- a/lua/commands.lua
+++ b/lua/commands.lua
@@ -1,0 +1,8 @@
+-- :JSONFormat to format current line (or visual selection) as JSON
+vim.api.nvim_create_user_command(
+  'JSONFormat',
+  '<line1>,<line2>!python -m json.tool',
+  {
+    range = true,
+  }
+)


### PR DESCRIPTION
The command :JSONFormat will format the current line (which is assumed to be a JSON string) as a readable indented with nesting object.

If a visual selection is present, it will be used rather than the current line.

See https://salferrarello.com/vim-json-format/

Resolves #8