### PR TITLE
Add support to use GBrowse with GitHub

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -85,6 +85,7 @@ require("lazy").setup({
 		end
 	},
 	"tpope/vim-fugitive",
+	"tpope/vim-rhubarb",
 	{
 		"vim-airline/vim-airline",
 		config = function()


### PR DESCRIPTION
When viewing a file in a local repo from GitHub we can now:

1. Type shift+v to select the line
2. Followed by the command :'<,'>GBrowse

This will take use to the GitHub URL to view the file with the line highlighted.

Resolves #14