### PR TITLE
Add bracket mappings for quickfix navigation

### DIFF
--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -30,5 +30,11 @@ set("n", "[B", ":bfirst<CR>");
 set("n", "]b", ":bnext<CR>");
 set("n", "]B", ":blast<CR>");
 
+-- Map Quickfix navigation [Q, [q, ]q, ]Q
+set("n", "[q", ":cprev<CR>");
+set("n", "[Q", ":cfirst<CR>");
+set("n", "]q", ":cnext<CR>");
+set("n", "]Q", ":clast<CR>");
+
 -- Select content you just pasted.
 vim.keymap.set("n", "gp", "`[V`]")


### PR DESCRIPTION
[q for :cprev
[Q for :cfirst
]q for :cnext
]Q for :clast

These are the same mappings
https://github.com/tpope/vim-unimpaired uses

Resolves #17