### PR TITLE
Add <leader>p mapping to paste characterwise

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -50,3 +50,4 @@ local function paste_character_wise()
 		vim.api.nvim_paste(register_value, true, -1)
 	end
 end
+vim.keymap.set('n', '<leader>p', paste_character_wise, { desc = "Paste characterwise" })

--- a/init.lua
+++ b/init.lua
@@ -39,15 +39,20 @@ require("lazy").setup('plugins',
   },
 })
 
-local function paste_characterwise()
-	local register_value = vim.fn.getreg(vim.v.register)
-	if vim.fn.getregtype(vim.v.register) == "V" then
-		-- Register is linewise
-		-- Paste characterwise and trim trailing newline
-		vim.api.nvim_paste(register_value:gsub("\n$", ""), true, -1)
-	else
-		-- Default paste behavior.
-		vim.api.nvim_paste(register_value, true, -1)
-	end
-end
-vim.keymap.set('n', '<leader>p', paste_characterwise, { desc = "Paste characterwise" })
+vim.keymap.set(
+	'n',
+	'<leader>p',
+	function()
+		local register_value = vim.fn.getreg(vim.v.register)
+		if vim.fn.getregtype(vim.v.register) == "V" then
+			-- Register is linewise
+			-- Paste characterwise and trimming leading spaces and trailing
+			-- spaces and changelog.
+			vim.api.nvim_paste(register_value:gsub("%s*\n$", ""):gsub("^%s*", ""), true, -1)
+		else
+			-- Default paste behavior.
+			vim.api.nvim_paste(register_value, true, -1)
+		end
+	end,
+	{ desc = "Paste characterwise" }
+)

--- a/init.lua
+++ b/init.lua
@@ -39,7 +39,7 @@ require("lazy").setup('plugins',
   },
 })
 
-local function paste_character_wise()
+local function paste_characterwise()
 	local register_value = vim.fn.getreg(vim.v.register)
 	if vim.fn.getregtype(vim.v.register) == "V" then
 		-- Register is linewise
@@ -50,4 +50,4 @@ local function paste_character_wise()
 		vim.api.nvim_paste(register_value, true, -1)
 	end
 end
-vim.keymap.set('n', '<leader>p', paste_character_wise, { desc = "Paste characterwise" })
+vim.keymap.set('n', '<leader>p', paste_characterwise, { desc = "Paste characterwise" })

--- a/init.lua
+++ b/init.lua
@@ -38,3 +38,15 @@ require("lazy").setup('plugins',
     },
   },
 })
+
+local function paste_character_wise()
+	local register_value = vim.fn.getreg(vim.v.register)
+	if vim.fn.getregtype(vim.v.register) == "V" then
+		-- Register is linewise
+		-- Paste characterwise and trim trailing newline
+		vim.api.nvim_paste(register_value:gsub("\n$", ""), true, -1)
+	else
+		-- Default paste behavior.
+		vim.api.nvim_paste(register_value, true, -1)
+	end
+end


### PR DESCRIPTION
Add <leader>p mapping to paste characterwise even if the register being pasted is linewise.

In addition to pasting characterwise, the trailing line break is removed.

This mapping pastes characterswise and blockwise registers in the same manner as "p" in normal mode

Resolves #26