### PR TITLE
Disable phpstan in ALE

### DIFF
--- a/lua/plugins/ale.lua
+++ b/lua/plugins/ale.lua
@@ -1,3 +1,8 @@
 return {
 	"dense-analysis/ale",
+	config = function()
+		-- Disable PHPStan linter in ALE. Temporary workaround for project throwing "Function not found." errors.
+		-- See: https://github.com/salcode/salcode-nvim/issues/30
+		vim.g.ale_linters_ignore = { "phpstan" }
+	end,
 }


### PR DESCRIPTION
Disable phpstan in ALE to prevent "Function not found" error messages.

Resolves #30