### PR TITLE
Add paste-characterwise.nvim

### DIFF
--- a/lua/plugins/paste-characterwise.lua
+++ b/lua/plugins/paste-characterwise.lua
@@ -1,5 +1,5 @@
 return {
-  "salcode/paste-characterwise.nvim",
+  "https://codeberg.org/salcode/paste-characterwise.nvim",
 	config = function()
 		vim.keymap.set(
 			'n',

--- a/lua/plugins/paste-characterwise.lua
+++ b/lua/plugins/paste-characterwise.lua
@@ -1,0 +1,11 @@
+return {
+	dir = "~/code/nvim-plugins/paste-characterwise.nvim",
+	config = function()
+		vim.keymap.set(
+			'n',
+			'<leader>p',
+			require("paste-characterwise").paste,
+			{ desc = "Paste characterwise" }
+		)
+	end,
+}

--- a/lua/plugins/paste-characterwise.lua
+++ b/lua/plugins/paste-characterwise.lua
@@ -1,5 +1,5 @@
 return {
-	dir = "~/code/nvim-plugins/paste-characterwise.nvim",
+  "salcode/paste-characterwise.nvim",
 	config = function()
 		vim.keymap.set(
 			'n',


### PR DESCRIPTION
Add plugin salcode/paste-characterwise.nvim and map to <leader>p (i.e. <space>p)

This plugin allows pasting a buffer characterwise (even when the data in the buffer is linewise)

Resolves #26