### PR TITLE
Add nrformats option blank for number increment

### DIFF
--- a/lua/options.lua
+++ b/lua/options.lua
@@ -22,4 +22,4 @@ o.incsearch = true
 o.iskeyword:append "-"
 o.showtabline = 2 -- always show tabline
 o.cursorline = true
-o.nrformats:append('blank')
+o.nrformats:append 'blank'

--- a/lua/options.lua
+++ b/lua/options.lua
@@ -22,3 +22,4 @@ o.incsearch = true
 o.iskeyword:append "-"
 o.showtabline = 2 -- always show tabline
 o.cursorline = true
+o.nrformats:append('blank')


### PR DESCRIPTION
This option modifies CTRL-a and CTRL-x for
increment/decrement numbers

Without this setting, Vim "increments"
sprint-23 to sprint-22 (because it interprets -22 as negative)

With the setting, Vim differentiates between

sprint-23 (increments to sprint-24)

and

-23 (increments to -22)

See https://salferrarello.com/vim-increment-number-with-dash/

Resolves #38